### PR TITLE
Update LocalMultiplayer for REPO v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# v1.4.1 EMPRESS
+
+- Updated compile references for R.E.P.O. v4.
+- Rebranded plugin metadata and output folder for EMPRESS.
+- Removed the boot-time Steam validity check that could quit the game before Photon/Steam auth setup completed.
+- Preserved the existing `LocalMultiplayer/global.cfg` path so existing Photon App IDs keep working.
+- Kept the original MIT license notice from ZehsTeam.
+
+# v1.4.0
+
+- Updated for R.E.P.O. v0.3.0.

--- a/LocalMultiplayer.sln
+++ b/LocalMultiplayer.sln
@@ -1,4 +1,4 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.12.35527.113 d17.12

--- a/LocalMultiplayer/ConfigManager.cs
+++ b/LocalMultiplayer/ConfigManager.cs
@@ -1,6 +1,6 @@
-﻿using BepInEx.Configuration;
+using BepInEx.Configuration;
 
-namespace com.github.zehsteam.LocalMultiplayer;
+namespace com.empress.LocalMultiplayer;
 
 internal static class ConfigManager
 {

--- a/LocalMultiplayer/Extensions/StringExtensions.cs
+++ b/LocalMultiplayer/Extensions/StringExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace com.github.zehsteam.LocalMultiplayer.Extensions;
+namespace com.empress.LocalMultiplayer.Extensions;
 
 internal static class StringExtensions
 {

--- a/LocalMultiplayer/Helpers/GlobalSaveHelper.cs
+++ b/LocalMultiplayer/Helpers/GlobalSaveHelper.cs
@@ -1,7 +1,7 @@
-﻿using com.github.zehsteam.LocalMultiplayer.Objects;
+using com.empress.LocalMultiplayer.Objects;
 using System.Collections.Generic;
 
-namespace com.github.zehsteam.LocalMultiplayer.Helpers;
+namespace com.empress.LocalMultiplayer.Helpers;
 
 internal static class GlobalSaveHelper
 {

--- a/LocalMultiplayer/Helpers/SteamHelper.cs
+++ b/LocalMultiplayer/Helpers/SteamHelper.cs
@@ -1,6 +1,4 @@
-﻿using Steamworks;
-
-namespace com.github.zehsteam.LocalMultiplayer.Helpers;
+namespace com.empress.LocalMultiplayer.Helpers;
 
 internal static class SteamHelper
 {
@@ -15,23 +13,5 @@ internal static class SteamHelper
         randomPart += (uint)random.Next(0, int.MaxValue);
 
         return steamIdBase + randomPart;
-    }
-
-    public static bool IsValidClient()
-    {
-        if (SteamClient.Name == "IGGGAMES")
-            return false;
-
-        if (SteamClient.SteamId == 12345678)
-            return false;
-
-        if (SteamClient.AppId == 480)
-            return false;
-
-        AuthTicket authTicket = SteamManager.instance.steamAuthTicket;
-        if (authTicket == null) return false;
-
-        BeginAuthResult beginAuthResult = SteamUser.BeginAuthSession(authTicket.Data, SteamClient.SteamId);
-        return beginAuthResult == BeginAuthResult.OK;
     }
 }

--- a/LocalMultiplayer/LocalMultiplayer.csproj
+++ b/LocalMultiplayer/LocalMultiplayer.csproj
@@ -1,18 +1,18 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     
-    <AssemblyName>com.github.zehsteam.$(MSBuildProjectName)</AssemblyName> <!-- PLUGIN_GUID -->
-    <Product>$(MSBuildProjectName)</Product>                               <!-- PLUGIN_NAME -->
-    <Version>1.4.0</Version>                                               <!-- PLUGIN_VERSION -->
-    <Authors>Zehs</Authors>
-    <Description>Play multiplayer locally with one Steam account.</Description>
-    <Copyright>Copyright © 2025 Zehs</Copyright>
+    <AssemblyName>com.empress.$(MSBuildProjectName)</AssemblyName>          <!-- PLUGIN_GUID -->
+    <Product>EMPRESS Local Multiplayer</Product>                            <!-- PLUGIN_NAME -->
+    <Version>1.4.1</Version>                                                <!-- PLUGIN_VERSION -->
+    <Authors>EMPRESS; Zehs</Authors>
+    <Description>EMPRESS fork for R.E.P.O. v4 local multiplayer with one Steam account.</Description>
+    <Copyright>Original copyright © 2025 Zehs. EMPRESS fork © 2026.</Copyright>
     
-    <RootNamespace>com.github.zehsteam.$(MSBuildProjectName)</RootNamespace>
+    <RootNamespace>com.empress.$(MSBuildProjectName)</RootNamespace>
     
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     
@@ -46,7 +46,7 @@
     <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="UnityEngine.Modules" Version="2022.3.62" IncludeAssets="compile" PrivateAssets="all" />
-    <PackageReference Include="R.E.P.O.GameLibs.Steam" Version="0.3.0-ngd.0" />
+    <PackageReference Include="R.E.P.O.GameLibs.Steam" Version="0.4.0-ngd.0" />
   </ItemGroup>
   
   <!-- Gale profile names -->
@@ -60,7 +60,7 @@
     <GaleDataFolder>$(AppData)\com.kesomannen.gale</GaleDataFolder>
     <GaleProfilesFolder>$(GaleDataFolder)\$(Game)\profiles</GaleProfilesFolder>
     <BepInExPluginsFolder>$(GaleProfilesFolder)\$(GaleProfileName)\BepInEx\plugins</BepInExPluginsFolder>
-    <PluginFolder>$(BepInExPluginsFolder)\Zehs-$(MSBuildProjectName)</PluginFolder>
+    <PluginFolder>$(BepInExPluginsFolder)\Empress-$(MSBuildProjectName)</PluginFolder>
   </PropertyGroup>
 
   <Target Name="CopyToGalePluginsFolder" AfterTargets="PostBuildEvent">

--- a/LocalMultiplayer/Logger.cs
+++ b/LocalMultiplayer/Logger.cs
@@ -1,6 +1,6 @@
-﻿using BepInEx.Logging;
+using BepInEx.Logging;
 
-namespace com.github.zehsteam.LocalMultiplayer;
+namespace com.empress.LocalMultiplayer;
 
 internal static class Logger
 {

--- a/LocalMultiplayer/Managers/SteamAccountManager.cs
+++ b/LocalMultiplayer/Managers/SteamAccountManager.cs
@@ -1,12 +1,12 @@
-﻿using com.github.zehsteam.LocalMultiplayer.Helpers;
-using com.github.zehsteam.LocalMultiplayer.Objects;
+using com.empress.LocalMultiplayer.Helpers;
+using com.empress.LocalMultiplayer.Objects;
 using Photon.Pun;
 using Steamworks;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
-namespace com.github.zehsteam.LocalMultiplayer.Managers;
+namespace com.empress.LocalMultiplayer.Managers;
 
 internal static class SteamAccountManager
 {

--- a/LocalMultiplayer/Objects/JsonSave.cs
+++ b/LocalMultiplayer/Objects/JsonSave.cs
@@ -1,11 +1,11 @@
-﻿using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Linq;
 using System;
 using System.IO;
 using System.Text;
 using System.Threading;
 using UnityEngine;
 
-namespace com.github.zehsteam.LocalMultiplayer.Objects;
+namespace com.empress.LocalMultiplayer.Objects;
 
 internal class JsonSave : IDisposable
 {

--- a/LocalMultiplayer/Objects/JsonSaveValue.cs
+++ b/LocalMultiplayer/Objects/JsonSaveValue.cs
@@ -1,4 +1,4 @@
-﻿namespace com.github.zehsteam.LocalMultiplayer.Objects;
+namespace com.empress.LocalMultiplayer.Objects;
 
 internal class JsonSaveValue<T>(JsonSave jsonSave, string key, T defaultValue = default)
 {

--- a/LocalMultiplayer/Objects/SteamAccount.cs
+++ b/LocalMultiplayer/Objects/SteamAccount.cs
@@ -1,6 +1,6 @@
-﻿using System;
+using System;
 
-namespace com.github.zehsteam.LocalMultiplayer.Objects;
+namespace com.empress.LocalMultiplayer.Objects;
 
 public struct SteamAccount : IEquatable<SteamAccount>
 {

--- a/LocalMultiplayer/Patches/DataDirectorPatch.cs
+++ b/LocalMultiplayer/Patches/DataDirectorPatch.cs
@@ -1,9 +1,9 @@
-﻿using com.github.zehsteam.LocalMultiplayer.Managers;
+using com.empress.LocalMultiplayer.Managers;
 using HarmonyLib;
 using Photon.Pun;
 using Photon.Realtime;
 
-namespace com.github.zehsteam.LocalMultiplayer.Patches;
+namespace com.empress.LocalMultiplayer.Patches;
 
 [HarmonyPatch(typeof(DataDirector))]
 internal static class DataDirectorPatch

--- a/LocalMultiplayer/Patches/InputManagerPatch.cs
+++ b/LocalMultiplayer/Patches/InputManagerPatch.cs
@@ -1,7 +1,7 @@
-﻿using com.github.zehsteam.LocalMultiplayer.Managers;
+using com.empress.LocalMultiplayer.Managers;
 using HarmonyLib;
 
-namespace com.github.zehsteam.LocalMultiplayer.Patches;
+namespace com.empress.LocalMultiplayer.Patches;
 
 [HarmonyPatch(typeof(InputManager))]
 internal static class InputManagerPatch

--- a/LocalMultiplayer/Patches/MenuPageMainPatch.cs
+++ b/LocalMultiplayer/Patches/MenuPageMainPatch.cs
@@ -1,10 +1,10 @@
-﻿using com.github.zehsteam.LocalMultiplayer.Helpers;
-using com.github.zehsteam.LocalMultiplayer.Managers;
+using com.empress.LocalMultiplayer.Helpers;
+using com.empress.LocalMultiplayer.Managers;
 using HarmonyLib;
 using Steamworks;
 using Steamworks.Data;
 
-namespace com.github.zehsteam.LocalMultiplayer.Patches;
+namespace com.empress.LocalMultiplayer.Patches;
 
 [HarmonyPatch(typeof(MenuPageMain))]
 internal static class MenuPageMainPatch

--- a/LocalMultiplayer/Patches/NetworkManagerPatch.cs
+++ b/LocalMultiplayer/Patches/NetworkManagerPatch.cs
@@ -1,7 +1,7 @@
-﻿using com.github.zehsteam.LocalMultiplayer.Managers;
+using com.empress.LocalMultiplayer.Managers;
 using HarmonyLib;
 
-namespace com.github.zehsteam.LocalMultiplayer.Patches;
+namespace com.empress.LocalMultiplayer.Patches;
 
 [HarmonyPatch(typeof(NetworkManager))]
 internal static class NetworkManagerPatch

--- a/LocalMultiplayer/Patches/PlayerAvatarPatch.cs
+++ b/LocalMultiplayer/Patches/PlayerAvatarPatch.cs
@@ -1,8 +1,8 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using Photon.Pun;
 using Steamworks;
 
-namespace com.github.zehsteam.LocalMultiplayer.Patches;
+namespace com.empress.LocalMultiplayer.Patches;
 
 [HarmonyPatch(typeof(PlayerAvatar))]
 internal static class PlayerAvatarPatch

--- a/LocalMultiplayer/Patches/SteamClientPatch.cs
+++ b/LocalMultiplayer/Patches/SteamClientPatch.cs
@@ -1,8 +1,8 @@
-﻿using com.github.zehsteam.LocalMultiplayer.Managers;
+using com.empress.LocalMultiplayer.Managers;
 using HarmonyLib;
 using Steamworks;
 
-namespace com.github.zehsteam.LocalMultiplayer.Patches;
+namespace com.empress.LocalMultiplayer.Patches;
 
 [HarmonyPatch(typeof(SteamClient))]
 internal static class SteamClientPatch

--- a/LocalMultiplayer/Patches/SteamManagerPatch.cs
+++ b/LocalMultiplayer/Patches/SteamManagerPatch.cs
@@ -1,14 +1,13 @@
-﻿using com.github.zehsteam.LocalMultiplayer.Helpers;
-using com.github.zehsteam.LocalMultiplayer.Managers;
+using com.empress.LocalMultiplayer.Helpers;
+using com.empress.LocalMultiplayer.Managers;
 using HarmonyLib;
 using Photon.Pun;
 using Photon.Realtime;
 using Steamworks;
 using Steamworks.Data;
 using System;
-using UnityEngine;
 
-namespace com.github.zehsteam.LocalMultiplayer.Patches;
+namespace com.empress.LocalMultiplayer.Patches;
 
 [HarmonyPatch(typeof(SteamManager))]
 internal static class SteamManagerPatch
@@ -19,14 +18,6 @@ internal static class SteamManagerPatch
     private static void AwakePatch()
     {
         SteamAccountManager.Initialize();
-    }
-
-    [HarmonyPatch(nameof(SteamManager.Start))]
-    [HarmonyPostfix]
-    private static void StartPatch()
-    {
-        if (!SteamHelper.IsValidClient())
-            Application.Quit();
     }
 
     [HarmonyPatch(nameof(SteamManager.OnLobbyCreated))]

--- a/LocalMultiplayer/Plugin.cs
+++ b/LocalMultiplayer/Plugin.cs
@@ -1,10 +1,10 @@
-﻿using BepInEx;
+using BepInEx;
 using BepInEx.Configuration;
-using com.github.zehsteam.LocalMultiplayer.Objects;
-using com.github.zehsteam.LocalMultiplayer.Patches;
+using com.empress.LocalMultiplayer.Objects;
+using com.empress.LocalMultiplayer.Patches;
 using HarmonyLib;
 
-namespace com.github.zehsteam.LocalMultiplayer;
+namespace com.empress.LocalMultiplayer;
 
 [BepInPlugin(MyPluginInfo.PLUGIN_GUID, MyPluginInfo.PLUGIN_NAME, MyPluginInfo.PLUGIN_VERSION)]
 internal class Plugin : BaseUnityPlugin

--- a/LocalMultiplayer/Utils.cs
+++ b/LocalMultiplayer/Utils.cs
@@ -1,17 +1,19 @@
-﻿using BepInEx;
+using BepInEx;
 using BepInEx.Configuration;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
 using UnityEngine;
 
-namespace com.github.zehsteam.LocalMultiplayer;
+namespace com.empress.LocalMultiplayer;
 
 internal static class Utils
 {
+    private const string PersistentDataFolderName = "LocalMultiplayer";
+
     public static string GetPluginPersistentDataPath()
     {
-        return Path.Combine(Application.persistentDataPath, MyPluginInfo.PLUGIN_NAME);
+        return Path.Combine(Application.persistentDataPath, PersistentDataFolderName);
     }
 
     public static ConfigFile CreateConfigFile(BaseUnityPlugin plugin, string path, string name = null, bool saveOnInit = false)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# LocalMultiplayer
+# EMPRESS Local Multiplayer
 
-[![GitHub](https://img.shields.io/badge/GitHub-LocalMultiplayer-brightgreen?style=for-the-badge&logo=GitHub)](https://github.com/ZehsTeam/REPO-LocalMultiplayer)
+[![Upstream GitHub](https://img.shields.io/badge/Upstream-LocalMultiplayer-brightgreen?style=for-the-badge&logo=GitHub)](https://github.com/ZehsTeam/REPO-LocalMultiplayer)
 [![Thunderstore Version](https://img.shields.io/thunderstore/v/Zehs/LocalMultiplayer?style=for-the-badge&logo=thunderstore&logoColor=white)](https://thunderstore.io/c/repo/p/Zehs/LocalMultiplayer/)
 [![Thunderstore Downloads](https://img.shields.io/thunderstore/dt/Zehs/LocalMultiplayer?style=for-the-badge&logo=thunderstore&logoColor=white)](https://thunderstore.io/c/repo/p/Zehs/LocalMultiplayer/)
 
-**Play multiplayer locally with one Steam account.**
+**EMPRESS fork for R.E.P.O. v4 local multiplayer with one Steam account.**
+
+This fork is based on ZehsTeam's MIT-licensed LocalMultiplayer mod. The original copyright and license are preserved in `LICENSE.txt`.
 
 ## Features
 
@@ -85,7 +87,7 @@ You can locate the config file at this path:
 |--------------------|-----------|----------|  
 | [R.E.P.O. Modding Server](https://discord.com/invite/vPJtKhYAFe) | `#released-mods` | [LocalMultiplayer](https://discord.com/channels/1344557689979670578/1352815417579798652) |
 
-- **GitHub Issues Page:** [LocalMultiplayer](https://github.com/ZehsTeam/REPO-LocalMultiplayer/issues)
+- **Original GitHub Issues Page:** [LocalMultiplayer](https://github.com/ZehsTeam/REPO-LocalMultiplayer/issues)
 - **My Links:** https://solo.to/crithaxxog
 
 <a href="https://ko-fi.com/zehsteam" target="_blank">

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "EMPRESS_LocalMultiplayer",
+  "version_number": "1.4.1",
+  "website_url": "https://github.com/ZehsTeam/REPO-LocalMultiplayer",
+  "description": "EMPRESS fork for R.E.P.O. v4 local multiplayer with one Steam account.",
+  "dependencies": [
+    "BepInEx-BepInExPack-5.4.2304"
+  ]
+}


### PR DESCRIPTION
Updates LocalMultiplayer for R.E.P.O. v4.

Changes:
- Updates compile references to R.E.P.O.GameLibs.Steam 0.4.0-ngd.0.
- Removes the boot-time Steam validity check that could call Application.Quit before Steam/Photon auth was ready.
- Preserves the existing LocalMultiplayer/global.cfg path so existing Photon App IDs still work.
- Keeps the original MIT license notice.

Tested locally on R.E.P.O. v4.x with BepInEx; game boots and local multiplayer loads.