### PR TITLE
Update LocalMultiplayer for REPO v4

### DIFF
--- a/LocalMultiplayer/Helpers/SteamHelper.cs
+++ b/LocalMultiplayer/Helpers/SteamHelper.cs
@@ -1,4 +1,4 @@
-﻿using Steamworks;
+using Steamworks;
 
 namespace com.github.zehsteam.LocalMultiplayer.Helpers;
 
@@ -28,10 +28,6 @@ internal static class SteamHelper
         if (SteamClient.AppId == 480)
             return false;
 
-        AuthTicket authTicket = SteamManager.instance.steamAuthTicket;
-        if (authTicket == null) return false;
-
-        BeginAuthResult beginAuthResult = SteamUser.BeginAuthSession(authTicket.Data, SteamClient.SteamId);
-        return beginAuthResult == BeginAuthResult.OK;
+        return true;
     }
 }

--- a/LocalMultiplayer/LocalMultiplayer.csproj
+++ b/LocalMultiplayer/LocalMultiplayer.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="UnityEngine.Modules" Version="2022.3.62" IncludeAssets="compile" PrivateAssets="all" />
-    <PackageReference Include="R.E.P.O.GameLibs.Steam" Version="0.3.0-ngd.0" />
+    <PackageReference Include="R.E.P.O.GameLibs.Steam" Version="0.4.0-ngd.0" />
   </ItemGroup>
   
   <!-- Gale profile names -->

--- a/LocalMultiplayer/Patches/SteamManagerPatch.cs
+++ b/LocalMultiplayer/Patches/SteamManagerPatch.cs
@@ -1,4 +1,4 @@
-﻿using com.github.zehsteam.LocalMultiplayer.Helpers;
+using com.github.zehsteam.LocalMultiplayer.Helpers;
 using com.github.zehsteam.LocalMultiplayer.Managers;
 using HarmonyLib;
 using Photon.Pun;


### PR DESCRIPTION
Updates LocalMultiplayer for R.E.P.O. v4.\n\nChanges:\n- Updates the R.E.P.O.GameLibs.Steam compile reference from 0.3.0-ngd.0 to 0.4.0-ngd.0.\n- Keeps the SteamManager.Start client validity check in place.\n- Removes only the auth-ticket-dependent validation from SteamHelper.IsValidClient, because steamAuthTicket is not guaranteed to exist yet during Start on v4 and can false-fail valid clients.\n- Preserves the existing checks for known invalid Steam client markers such as IGGGAMES, SteamId 12345678, and AppId 480.\n\nTested locally on R.E.P.O. v4.x with BepInEx; the game boots and LocalMultiplayer loads successfully.